### PR TITLE
feat: qinglong cron support

### DIFF
--- a/qinglong/exchange.ts
+++ b/qinglong/exchange.ts
@@ -1,0 +1,9 @@
+const notify = require('../sendNotify')
+const axios = require('axios')
+
+// 兑换体验卡
+!(async () => {
+  const {data: credit_data} = await axios(process.env.CREDIT_URL)
+  const message = credit_data.code === 0 ? '兑换任务执行完成' : credit_data.msg
+  await notify.sendNotify('wereadx', message); 
+})();

--- a/qinglong/read.ts
+++ b/qinglong/read.ts
@@ -1,0 +1,9 @@
+const notify = require('./sendNotify')
+const axios = require('axios')
+
+// 自动阅读
+!(async () => {
+  const {data: read_data} = await axios(process.env.AUTO_READ_URL)
+  const message = read_data.code === 0 ? '阅读任务执行完成' : read_data.msg
+  await notify.sendNotify('wereadx', message); 
+})();


### PR DESCRIPTION
- [x] 青龙面板：支持青龙面板实现定时任务和通知推送，支持的推送服务见 [链接](https://github.com/whyour/qinglong/blob/9ed107980c7dcecf888c1e2bfa1ba1ba9de2c629/sample/notify.js)

注：通知仅在定时任务执行后发送。

关联 issue: https://github.com/champkeh/wereadx/issues/29